### PR TITLE
Improve configuration: add 'align' and 'priority', and switch to actual objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Shortcuts
 
-Shortcuts let you add useful icons to the bottom status bar. You can add/edit your own icon appearance, command and tooltip by changing the pre-defeind settings (no code needed!).   
+Shortcuts let you add useful icons to the bottom status bar. You can add/edit your own icon appearance, command and tooltip by changing the pre-defeind settings (no code needed!).
 
 ## Features
 
@@ -16,19 +16,13 @@ Latest version of VSCode would be enough.
 
 This extension contributes the following settings:
 
-* `shortcuts.buttons`: define configurable buttons. Format: `icon, command, tooltip`. Default settings:
+* `shortcuts.buttons`: Define the desired shortcut buttons to be shown in the status bar.
+  This is either an array of comma-separated strings with format `icon, command, tooltip`,
+  or an array of objects with the following keys: `icon`, `command`, `tooltip`, `align`, `priority`.
+* `shortcuts.align`: Default alignment of the shortcut buttons; this can also be overridden per button.
+* `shortcuts.priority`: Default order priority of the shortcut buttons; this can also be overridden per button.
 
-  ```json
-  [
-    "file-binary , workbench.action.tasks.build , Run build task",
-    "beaker , workbench.action.tasks.test , Run test task",
-    "terminal , workbench.action.terminal.toggleTerminal , Toggle terminal panel",
-    "telescope , workbench.action.showCommands , Show command palette",
-    "bug, workbench.action.debug.start, Launch debug"
-  ]
-  ```
-
-Go to preference > workspace settings to change these settings. The changes will be automatically loaded up after VSCode restart.
+Go to `Preferences > Settings` to change these settings. Your changes changes will be applied after VSCode has been restarted.
 
 Commands are listed at [vscode doc site](https://code.visualstudio.com/docs/getstarted/keybindings#_default-keyboard-shortcuts). To find all icons list please check the link [octicons.github.com](https://octicons.github.com)
 
@@ -37,6 +31,10 @@ Commands are listed at [vscode doc site](https://code.visualstudio.com/docs/gets
 Please see: [issues](https://github.com/gizak/vscode-shortcuts/issues).
 
 ## Release Notes
+
+### 0.1.0
+
+Allow to configure alignment and order priority of shortcut buttons, and upgrade configuration from comma-separated strings to actual objects.
 
 ### 0.0.1
 

--- a/package.json
+++ b/package.json
@@ -27,14 +27,44 @@
             "properties": {
                 "shortcuts.buttons": {
                     "type": "array",
-                    "description": "Setup shortcut buttons. Format: ICON,COMMAND,TOOLTIP",
+                    "description": "Define the desired shortcut buttons to be shown in the status bar. This is either an array of comma-seperated strings with format `icon, command, tooltip`, or an array of objects with the following keys: `icon`, `command`, `tooltip`, `align`, `priority`.",
                     "default": [
-                        "file-binary , workbench.action.tasks.build , Run build task",
-                        "beaker , workbench.action.tasks.test , Run test task",
-                        "terminal , workbench.action.terminal.toggleTerminal , Toggle terminal panel",
-                        "telescope , workbench.action.showCommands , Show command palette",
-                        "bug, workbench.action.debug.start, Launch debug"
+                        {
+                            "icon": "file-binary",
+                            "command": "workbench.action.tasks.build",
+                            "tooltip": "Run build tasks"
+                        },
+                        {
+                            "icon": "beaker",
+                            "command": "workbench.action.tasks.test",
+                            "tooltip": "Run test tasks"
+                        },
+                        {
+                            "icon": "terminal",
+                            "command": "workbench.action.terminal.toggleTerminal",
+                            "tooltip": "Toggle terminal panel"
+                        },
+                        {
+                            "icon": "telescope",
+                            "command": "workbench.action.showCommands",
+                            "tooltip": "Show command palette"
+                        },
+                        {
+                            "icon": "bug",
+                            "command": "workbench.action.debug.start",
+                            "tooltip": "Launch debugger"
+                        }
                     ]
+                },
+                "shortcuts.align": {
+                    "type": "string",
+                    "description": "Default alignment of the shortcut buttons; this can also be overridden per button.",
+                    "default": "left"
+                },
+                "shortcuts.priority": {
+                    "type": ["number", "null"],
+                    "description": "Default order priority of the shortcut buttons; this can also be overridden per button.",
+                    "default": null
                 }
             }
         }

--- a/src/shortcuts.ts
+++ b/src/shortcuts.ts
@@ -2,23 +2,33 @@ import {window, commands, workspace, StatusBarAlignment, StatusBarItem} from 'vs
 
 export class Shortcuts {
     private buttons: StatusBarItem[]
+    private align: 'left'|'right'
+    private priority: number
 
     constructor(config: any) {
+        const align = config.align;
+        const priority = config.priority;
         const btns = config.buttons;
+
+        if (align) {
+            this.align = align;
+        }
+        if (priority) {
+            this.priority = priority;
+        }
         if (btns) {
-            this.buttons = btns.map( (btnTx: string): StatusBarItem => {
-                const [icon,cmd,tip] = btnTx.split(',').map((tx: string): string => {return tx.trim()});
-                const btn = window.createStatusBarItem(StatusBarAlignment.Left);
-                btn.text=`$(${icon})`;
-                btn.command = cmd;
-                btn.tooltip = tip;
-                return btn;
-            })
+            this.buttons = btns.map( (btnTx: string|Object): StatusBarItem => {
+                if (typeof btnTx === 'object') {
+                    return this.fromObjectConfig(btnTx)
+                } else {
+                    return this.fromStringConfig(btnTx)
+                }
+            });
         }
     }
 
     show() {
-        this.buttons.forEach(btn=>{
+        this.buttons.forEach(btn => {
             btn.show();
         });
     }
@@ -27,5 +37,32 @@ export class Shortcuts {
         this.buttons.forEach(btn => {
             btn.dispose();
         });
+    }
+
+    private fromStringConfig(btnTx: string): StatusBarItem {
+        const [icon,cmd,tip] = btnTx.split(',').map((tx: string): string => {return tx.trim()});
+        const btn = window.createStatusBarItem(StatusBarAlignment.Left);
+        btn.text=`$(${icon})`;
+        btn.command = cmd;
+        btn.tooltip = tip;
+        return btn;
+    }
+
+    private fromObjectConfig(btnTx: any): StatusBarItem {
+        const { icon, command, tooltip, align, priority } = btnTx;
+        const btn = window.createStatusBarItem( this.alignFromString(align || this.align), (priority || this.priority) );
+        btn.text=`$(${icon})`;
+        btn.command = command;
+        btn.tooltip = tooltip;
+        return btn;
+    }
+
+    private alignFromString(align: string): StatusBarAlignment {
+        switch (align) {
+            case 'right':
+                return StatusBarAlignment.Right;
+            case 'left': default:
+                return StatusBarAlignment.Left;
+        }
     }
 }


### PR DESCRIPTION
These changes will allow users to configure a default alignment and priority for all added shortcut buttons, and also allow them to override those settings per shortcut by switching from a comma-separated string configuration to actual, extendable objects.

The change is non-breaking, as the introduced settings will fall back to the same behaviour, and the old string-setting parser is left intact.

Please change the added code as desired.